### PR TITLE
feat: add shape shifter compatibility

### DIFF
--- a/assets/styles/epub/_fonts.scss
+++ b/assets/styles/epub/_fonts.scss
@@ -1,7 +1,28 @@
 @import '_font-stack-epub'; // Dynamically generated
 
 $serif-epub: serif !default;
-$font-1: "Palatino Linotype", "Book Antiqua", palatino, georgia, times, $serif-epub;
-$font-2: "Palatino Linotype", "Book Antiqua", palatino, georgia, times, $serif-epub;
-$font-3: "Palatino Linotype", "Book Antiqua", palatino, georgia, times, $serif-epub;
+$sans-serif-epub: sans-serif !default;
 
+// Load Shape Shifter fonts, if any. Must come after Global Typography snippet
+@import 'shapeshifter-font-stack-epub';
+
+$shapeshifter-font-1-is-serif: true !default;
+$shapeshifter-font-2-is-serif: true !default;
+
+// Insert custom fonts for your theme into the font stacks below. Always end the
+// stack with $serif-epub or $sans-serif-epub, as appropriate—this allows custom
+// language support to be added dynamically.
+
+@if variable-exists(shapeshifter-font-1) {
+  $font-1: $shapeshifter-font-1, if($shapeshifter-font-1-is-serif, $serif-epub, $sans-serif-epub);
+} @else {
+  $font-1: "Palatino Linotype", "Book Antiqua", palatino, georgia, times, $serif-epub;
+}
+
+@if variable-exists(shapeshifter-font-2) {
+  $font-2: $shapeshifter-font-2, if($shapeshifter-font-2-is-serif, $serif-epub, $sans-serif-epub);
+} @else {
+  $font-2: "Palatino Linotype", "Book Antiqua", palatino, georgia, times, $serif-epub;
+}
+
+$font-3: $font-2;

--- a/assets/styles/prince/_fonts.scss
+++ b/assets/styles/prince/_fonts.scss
@@ -2,9 +2,29 @@
 
 $serif-prince: serif !default;
 $sans-serif-prince: sans-serif !default;
-$font-1: "Linux Libertine", $serif-prince;
-$font-2: "Linux Biolinum", $sans-serif-prince;
-$font-3: "Linux Biolinum", $sans-serif-prince;
 
-@import 'LinuxBiolinum';
-@import 'LinuxLibertine';
+// Load Shape Shifter fonts, if any. Must come after Global Typography snippet
+@import 'shapeshifter-font-stack-prince';
+
+$shapeshifter-font-1-is-serif: true !default;
+$shapeshifter-font-2-is-serif: true !default;
+
+// Insert custom fonts for your theme into the font stacks below. Always end the
+// stack with $serif-prince or $sans-serif-prince, as appropriate—this allows
+// custom language support to be added dynamically.
+
+@if variable-exists(shapeshifter-font-1)  {
+  $font-1: $shapeshifter-font-1, if($shapeshifter-font-1-is-serif, $serif-prince, $sans-serif-prince);
+} @else {
+  $font-1: "Linux Libertine", $serif-prince;
+  @import 'LinuxLibertine';
+}
+
+@if variable-exists(shapeshifter-font-2) {
+  $font-2: $shapeshifter-font-2, if($shapeshifter-font-2-is-serif, $serif-prince, $sans-serif-prince);
+} @else {
+  $font-2: "Linux Biolinum", $sans-serif-prince;
+  @import 'LinuxBiolinum';
+}
+
+$font-3: $font-2;

--- a/assets/styles/web/_fonts.scss
+++ b/assets/styles/web/_fonts.scss
@@ -2,8 +2,29 @@
 
 $serif-web: serif !default;
 $sans-serif-web: sans-serif !default;
-$font-1: "Tinos", $serif-web;
-$font-2: "Galdeano", $sans-serif-web;
-$font-3: "Galdeano", $sans-serif-web;
 
-@import "https://fonts.googleapis.com/css?family=Galdeano|Tinos:400,400italic,700,700italic";
+// Load Shape Shifter fonts, if any. Must come after Global Typography snippet
+@import 'shapeshifter-font-stack-web';
+
+$shapeshifter-font-1-is-serif: true !default;
+$shapeshifter-font-2-is-serif: true !default;
+
+// Insert custom fonts for your theme into the font stacks below. Always end the
+// stack with $serif-web or $sans-serif-web, as appropriate—this allows custom
+// language support to be added dynamically.
+
+@if variable-exists(shapeshifter-font-1) {
+  $font-1: $shapeshifter-font-1, if($shapeshifter-font-1-is-serif, $serif-web, $sans-serif-web);
+} @else {
+  $font-1: "Tinos", $serif-web;
+  @import "https://fonts.googleapis.com/css?family=Tinos:400,400italic,700,700italic";
+}
+
+@if variable-exists(shapeshifter-font-2) {
+  $font-2: $shapeshifter-font-2, if($shapeshifter-font-2-is-serif, $serif-web, $sans-serif-web);
+} @else {
+  $font-2: "Galdeano", $sans-serif-web;
+  @import "https://fonts.googleapis.com/css?family=Galdeano";
+}
+
+$font-3: $font-2;

--- a/functions.php
+++ b/functions.php
@@ -9,3 +9,5 @@ function donham_theme_setup() {
 }
 
 add_action( 'after_setup_theme', 'donham_theme_setup' );
+
+add_filter( 'pb_is_shape_shifter_compatible', '__return_true' );


### PR DESCRIPTION
Issue pressbooks/ideas#431

This PR adds compatibility with the shape shifter feature allowing users to change the typography of the theme.

**How to test**

1. Enable Donham theme in **Appearance > Themes**
2. Visit the book's page and the theme should be applied normally without changes
3. Visit **Appearance > Theme Options** and change the font for Web, PDF, and EPUB
4. Visit the book's page once more and validate the font was modified accordingly
5. Generate PDF/EPUB exports and make sure changes are reflected in the exports as well